### PR TITLE
two-way binding for the model value

### DIFF
--- a/src/js/BzmRangeSliderMod.js
+++ b/src/js/BzmRangeSliderMod.js
@@ -558,6 +558,10 @@ function bzmFoundationSlider ($log, $document, $timeout) {
             if (scope.initvalues) scope.initWidget(scope.initvalues);
         });
 
+        // two-way binding if model value changes
+        scope.$watch ('ngModel', function (newValue) {
+          scope.setValue(newValue, 0);
+        });
     }
 
 return {


### PR DESCRIPTION
This makes the binding work two ways for the slider. e.g. if you have `<range-slider ng-model="foo"></range-slider>`, and later, `<input type="number" ng-model="foo">`, then when the slider changes, the input changes (which already worked), but with this addition, when the input changes, the slider will change as well. 

As with my previous commit, I'm not sure how this would work with dual sliders. I'm unclear how the logic works since it appears `scope.viewValue` is always set to one number, while it should probably be an array of two numbers in the case of dual.

Happy to contribute in making this a better module!
